### PR TITLE
fix: bank identifier in the manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -75,5 +75,6 @@
       "long_description": "Fetches your Materiel.net bills"
     }
   },
+  "banksTransactionRegExp": "\\bmateriel\.net\\b",
   "manifest_version": "2"
 }


### PR DESCRIPTION
To be compatible with the new version of cozy-banks, the connector need to declare the bank identifier in the manifest