### PR TITLE
fix: update webpack configuration for svg icon

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.6",
+  "version": "1.1.7",
   "name": "Materiel.net",
   "type": "konnector",
   "language": "node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cozy-konnector-materielnet",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "description": "",
     "repository": {
         "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,19 @@
 var path = require('path')
 const CopyPlugin = require('copy-webpack-plugin')
 const fs = require('fs')
+const SvgoInstance = require('svgo')
 
 const entry = require('./package.json').main
+
+const svgo = new SvgoInstance({
+  plugins: [
+    {
+      inlineStyles: {
+        onlyMatchedOnce: false
+      }
+    }
+  ]
+})
 
 let iconName
 try {
@@ -12,6 +23,7 @@ try {
 } catch (e) {
     console.error(`Unable to read the icon path from manifest: ${e}`)
 }
+const appIconRX = iconName && new RegExp(`[^/]*/${iconName}`)
 
 module.exports = {
     entry,
@@ -26,9 +38,24 @@ module.exports = {
             { from: 'manifest.konnector' },
             { from: 'package.json' },
             { from: 'README.md' },
-            { from: 'assets' },
+            { from: 'assets', transform: optimizeSVGIcon },
             { from: '.travis.yml' },
             { from: 'LICENSE' }
         ])
-    ]
+    ],
+  module: {
+    // to ignore the warnings like :
+    // WARNING in ../libs/node_modules/bindings/bindings.js 76:22-40
+    // Critical dependency: the request of a dependency is an expression
+    // Since we cannot change this dependency. I think it won't hide more important messages
+    exprContextCritical: false
+  }
+}
+
+function optimizeSVGIcon(buffer, path) {
+  if (appIconRX && path.match(appIconRX)) {
+    return svgo.optimize(buffer).then(resp => resp.data)
+  } else {
+    return buffer
+  }
 }


### PR DESCRIPTION
The next version of the cozy store will have problem displaying this connector's icon (some CSPs will force a bad display of it see https://github.com/svg/svgo/issues/1042#issuecomment-424160352).