### PR TITLE
Add auto captcha solving

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ class MaterielnetKonnector extends CookieKonnector {
                 if (err) {
                     logger.debug(err.message);
                     logger.error("Could not retrieve login token");
-                    return reject(new Error(errors.LOGIN_FAILED));
+                    return reject(new Error(errors.VENDOR_DOWN));
                 }
                 // Extract token
                 let token = "";


### PR DESCRIPTION
Hey nicofrand, 
We still have difficulties (captcha) in production.

We want to add auto captcha solving.
  It will work if a recaptcha key is present in the environnement (like in ours)
  If not, and a captcha is render, it will throw the same error as today ( .CAPTCHA )
  If no captcha, nothing change.

We hope that solving a captcha from time to time will help to whitelist our ip.
Moreover, one solving from time to time, allowed multiple account to fetch their bills before getting 'captched' again.

This pr add the logic and code to allowed that.
It has been tested on multiple accounts and the connector still connect and import bills without signs of regression. But please double check it with your account.

Let me know if you have questions

Lucas